### PR TITLE
Add support for armv6l architecture in install script for Raspberry Pi Zero

### DIFF
--- a/host-targets.js
+++ b/host-targets.js
@@ -90,6 +90,7 @@ HostTargets.TERMS = {
   arm64: { arch: 'aarch64' },
   aarch64: { arch: 'aarch64' },
   armv7l: { arch: 'armv7' },
+  armv6l: { arch: 'armv6' },
   earmv6hf: { arch: 'armhf' },
   arm: {},
   evbarm: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "build-classifier",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "build-classifier",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-classifier",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Determine Host Target Triplet (Arch, Libc, OS, Vendor) from a filenames / download URL and uname / User-Agent strings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Environment

- Device: Raspberry Pi Zero
- Operating System: Linux 6.6.31+rpi-rpi-v6
- Architecture: armv6l

## Issue

The install script https://webinstall.dev/api/installers/node@lts.sh fails to execute on Raspberry Pi Zero due to an invalid architecture value derived from the User-Agent string.

Example User-Agent string: `Linux/6.6.31+rpi-rpi-v6 armv6l/unknown gnu`

```
### https://github.com/webinstall/webi-installers/blob/5c12cb1fa7f01c851de912344a9d29e288ce6215/webi/webi.sh#L77C1-L86C1
$ echo $WEBI_UA
Linux/6.6.31+rpi-rpi-v6 armv6l/unknown gnu
```

## Changes

Updated the architecture detection map to include armv6l.
