### PR TITLE
chore(release): bump to v0.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "build-classifier",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "build-classifier",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "SEE LICENSE IN LICENSE"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-classifier",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Determine Host Target Triplet (Arch, Libc, OS, Vendor) from a filenames / download URL and uname / User-Agent strings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To signal that the latest change is not a breaking change.