### PR TITLE
chore(release): bump to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "build-classifier",
-  "version": "0.9.5",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "build-classifier",
-      "version": "0.9.5",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-classifier",
-  "version": "0.9.5",
+  "version": "1.0.0",
   "description": "Determine Host Target Triplet (Arch, Libc, OS, Vendor) from a filenames / download URL and uname / User-Agent strings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Not a breaking change, just confirming that it's fair to consider the API stable at this point.

If there is a breaking change in the future, it'll just be a v2.0.