### PR TITLE
ref: add POSIX.1-2024 terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Also compares versions lexicographically.
     "",
     "ANYOS",
     "posix_2017",
+    "posix_2024",
     "aix",
     "android",
     "darwin",

--- a/triplet.js
+++ b/triplet.js
@@ -195,7 +195,8 @@ var Triplet = ('object' === typeof module && exports) || {};
     SOLARIS: { os: 'solaris' },
 
     // Any
-    POSIX: { os: 'posix_2017', arch: 'ANYARCH', vendor: 'unknown' },
+    POSIX_2017: { os: 'posix_2017', arch: 'ANYARCH', vendor: 'unknown' },
+    POSIX_2024: { os: 'posix_2024', arch: 'ANYARCH', vendor: 'unknown' },
     WASI: { os: 'wasi', vendor: 'unknown' },
 
     // Arches
@@ -269,8 +270,9 @@ var Triplet = ('object' === typeof module && exports) || {};
   tpm['solaris'] = T.SOLARIS;
   tpm['solaris_11'] = T.SOLARIS;
   // System Interfaces (POSIX, WASI)
-  tpm['posix'] = T.POSIX;
-  tpm['posix_2017'] = T.POSIX;
+  tpm['posix'] = T.POSIX_2017;
+  tpm['posix_2017'] = T.POSIX_2017;
+  tpm['posix_2024'] = T.POSIX_2024;
   tpm['wasi'] = T.WASI;
 
   // OS + Arch

--- a/types.js
+++ b/types.js
@@ -3,7 +3,7 @@
 module.exports._types = true;
 
 /**
- * @typedef {""|"ANYOS"|"posix_2017"|"aix"|"android"|"darwin"|"dragonfly"|"freebsd"|"illumos"|"linux"|"netbsd"|"openbsd"|"plan9"|"solaris"|"sunos"|"wasi"|"windows"} OsString
+ * @typedef {""|"ANYOS"|"posix_2024"|"posix_2017"|"aix"|"android"|"darwin"|"dragonfly"|"freebsd"|"illumos"|"linux"|"netbsd"|"openbsd"|"plan9"|"solaris"|"sunos"|"wasi"|"windows"} OsString
  */
 
 /**


### PR DESCRIPTION
I'm not sure what it means yet, but a new POSIX is upon us!

- https://sortix.org/blog/posix-2024/
- https://www.reddit.com/r/programming/comments/1dfs2cf/posix_2024_has_been_published/
- https://news.ycombinator.com/item?id=40679809

Spec: <https://pubs.opengroup.org/onlinepubs/9799919799/>

# Things to look forward to

The updated list of utilities: <https://pubs.opengroup.org/onlinepubs/9799919799/idx/utilities.html>

- [pipefail](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_09_02)
   ```sh
   set -o pipefail
   ls /doesntexist | grep 'foo' # return 1
   ```
- [test](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/test.html) drops `-a` and `-o` in favor of && and ||
   ```diff
   - test -f /etc/passwd -a -s /etc/passwd
   + test -f /etc/passwd && test -s /etc/passwd
   ```
- unifying how Linuxes and BSDs read symlinks with [readlink](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/readlink.html) and [realpath](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/realpath.html)
   ```sh
   readlink
   realpath
   ```
- [timeout](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/timeout.html) to only allow a command to run for a specific amount of time via `SIGTERM`, `SIGCONT`, and `SIGKILL`
   ```sh
   timeout -k 10s -s SIGTERM 2m footask --fooarg
   ```
- [internationalization](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/msgfmt.html)
   ```sh
   gettext
   msgfmt
   ngettext
   xgettext
   ```