### PR TITLE
feat(x86_64): add v4 and ROCm

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Also compares versions lexicographically.
     "x86",
     "x86_64",
     "x86_64_v2",
-    "x86_64_v3"
+    "x86_64_v3",
+    "x86_64_v4",
+    "x86_64_rocm"
   ],
   "oses": [
     "",

--- a/host-targets.js
+++ b/host-targets.js
@@ -13,24 +13,31 @@ let reLeadingVer = /^\d([\d\.\-\+_])+/;
 //   gki = Generic Kernel Image
 //   qgki = Qualcomm Generic Kernel Image
 
+let X86_64 = {
+  x86_64_rocm: ['x86_64_rocm', 'x86_64_v4', 'x86_64_v3', 'x86_64_v2', 'x86_64'],
+  x86_64_v4: ['x86_64_v4', 'x86_64_v3', 'x86_64_v2', 'x86_64'],
+  x86_64_v3: ['x86_64_v3', 'x86_64_v2', 'x86_64', 'x86'],
+  x86_64_v2: ['x86_64_v2', 'x86_64', 'x86'],
+  x86_64: ['x86_64', 'x86'],
+};
+
 HostTargets.WATERFALL = {
   darwin: { aarch64: ['aarch64', 'x86_64'] },
-  windows: {
-    aarch64: ['aarch64', 'x86_64'],
-    x86_64_v3: ['x86_64_v3', 'x86_64_v2', 'x86_64', 'x86'],
-    x86_64_v2: ['x86_64_v2', 'x86_64', 'x86'],
-  },
-  linux: {
-    // NOTE: the libc:armhf will need to be installed
-    aarch64: ['aarch64', 'armv7a', 'armv7', 'armhf'],
-    x86_64_v3: ['x86_64_v3', 'x86_64_v2', 'x86_64', 'x86'],
-    x86_64_v2: ['x86_64_v2', 'x86_64', 'x86'],
-  },
-  ANYOS: {
+  windows: Object.assign(
+    {
+      aarch64: ['aarch64', 'x86_64'],
+    },
+    X86_64,
+  ),
+  linux: Object.assign(
+    {
+      // NOTE: the libc:armhf will need to be installed
+      aarch64: ['aarch64', 'armv7a', 'armv7', 'armhf'],
+    },
+    X86_64,
+  ),
+  ANYOS: Object.assign({}, X86_64, {
     // arches
-    x86_64_v3: ['x86_64_v3', 'x86_64_v2', 'x86_64'],
-    x86_64_v2: ['x86_64_v2', 'x86_64'],
-    x86_64: ['x86_64', 'x86'],
     armv7: ['armv7a', 'armv7', 'armhf', 'armv6', 'armel', 'armv5'],
     armv6: ['armv6', 'armel', 'armv5'],
     armv5: ['armv5', 'armel'],
@@ -45,7 +52,7 @@ HostTargets.WATERFALL = {
     // prefer 'bionic' because it's built-in
     // (TODO test to see if statically-compiled linux bins work)
     bionic: ['bionic', 'none'],
-  },
+  }),
 };
 
 // The Terms

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "build-classifier",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "build-classifier",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "SEE LICENSE IN LICENSE"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-classifier",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Determine Host Target Triplet (Arch, Libc, OS, Vendor) from a filenames / download URL and uname / User-Agent strings.",
   "main": "index.js",
   "scripts": {

--- a/triplet.js
+++ b/triplet.js
@@ -203,6 +203,8 @@ var Triplet = ('object' === typeof module && exports) || {};
     X86_64: { arch: 'x86_64' },
     X86_64_V2: { arch: 'x86_64_v2' },
     X86_64_V3: { arch: 'x86_64_v3' },
+    X86_64_V4: { arch: 'x86_64_v4' },
+    AMD64_ROCM: { arch: 'x86_64_rocm' },
     AARCH64: { arch: 'aarch64' },
     X86: { arch: 'x86' },
     ARMV7A: { arch: 'armv7a' },
@@ -293,10 +295,13 @@ var Triplet = ('object' === typeof module && exports) || {};
   tpm['x86_64_v1'] = T.X86_64;
   tpm['x86_64_v2'] = T.X86_64_V2;
   tpm['x86_64_v3'] = T.X86_64_V3;
+  tpm['x86_64_v4'] = T.X86_64_V4;
   tpm['amd64'] = T.X86_64;
   tpm['amd64_v1'] = T.X86_64;
   tpm['amd64_v2'] = T.X86_64_V2;
   tpm['amd64_v3'] = T.X86_64_V3;
+  tpm['amd64_v4'] = T.X86_64_V4;
+  tpm['amd64_rocm'] = T.AMD64_ROCM;
   tpm['x64'] = T.X86_64;
   tpm['aarch64'] = T.AARCH64;
   tpm['arm64'] = T.AARCH64;

--- a/types.js
+++ b/types.js
@@ -11,7 +11,7 @@ module.exports._types = true;
  */
 
 /**
- * @typedef {""|"ANYARCH"|"POSIX"|"aarch64"|"armel"|"armhf"|"armv6"|"armv7"|"armv7a"|"loong64"|"mips"|"mips64"|"mips64el"|"mips64r6"|"mips64r6el"|"mipsel"|"mipsr6"|"mipsr6el"|"ppc"|"ppc64"|"ppc64le"|"riscv64"|"s390x"|"wasm32"|"x86"|"x86_64"|"x86_64_v2"|"x86_64_v3"} ArchString
+ * @typedef {""|"ANYARCH"|"POSIX"|"aarch64"|"armel"|"armhf"|"armv6"|"armv7"|"armv7a"|"loong64"|"mips"|"mips64"|"mips64el"|"mips64r6"|"mips64r6el"|"mipsel"|"mipsr6"|"mipsr6el"|"ppc"|"ppc64"|"ppc64le"|"riscv64"|"s390x"|"wasm32"|"x86"|"x86_64"|"x86_64_v2"|"x86_64_v3"|"x86_64_v4"|"x86_64_rocm"} ArchString
  */
 
 /**


### PR DESCRIPTION
Investigated due to to @jojobyte's issue with the latest `ollama`.

I'm not entirely sure that `ROCm` will be long-lived enough to warrant inclusion, but if not we can always remove it and change the few installers that need it.

As it stands, however, we can only classify those builds. We can't actually install them because we don't yet have a mechanism to detect cpu-level features.

See also:
- <https://github.com/webinstall/webi-installers/issues/879>
- <https://github.com/golang/go/issues/45453>