### PR TITLE
fix(maybeInstallable): match TERMS_EXTS_NON_BUILD against filename, not URL

### DIFF
--- a/triplet.js
+++ b/triplet.js
@@ -456,14 +456,21 @@ var Triplet = ('object' === typeof module && exports) || {};
       }
     }
 
+    // Check the filename, not the full URL. Some download URLs are API
+    // endpoints whose path tail looks like an extension match — e.g.
+    // `.../tarball/v1.0.1` ends with `.1` (a TERMS_EXTS_NON_BUILD entry
+    // intended for `manpage.1`), causing maybeInstallable to falsely
+    // reject any package version ending in `.1`. The filename itself is
+    // the canonical source for extension classification.
+    let filename = build.name || build.download;
     for (let ext of Triplet.TERMS_EXTS_NON_BUILD) {
-      if (build.download.endsWith(ext)) {
+      if (filename.endsWith(ext)) {
         return false;
       }
     }
 
     for (let re of Triplet._RE_TERMS_NON_BUILD) {
-      if (re.test(build.download)) {
+      if (re.test(filename)) {
         return false;
       }
     }


### PR DESCRIPTION
## Summary

Fix a false-positive in `Triplet.maybeInstallable` that drops package versions ending in `.1` when the download URL is a GitHub source-archive endpoint.

## Bug

`maybeInstallable` checks each entry in `TERMS_EXTS_NON_BUILD` (which includes `.1` for matching man-page section-1 files like `mytool.1`) against the full `build.download` URL:

```js
for (let ext of Triplet.TERMS_EXTS_NON_BUILD) {
    if (build.download.endsWith(ext)) {
        return false;
    }
}
```

For packages that publish only as GitHub source archives, the download URL is the API endpoint:

```
https://api.github.com/repos/bnnanet/serviceman/tarball/v1.0.1
                                                          ^^
                                                  ends with ".1"
```

`maybeInstallable` returns `false`, `_classify` silently returns `null`, and `transformAndUpdate`'s "ignore known, non-package extensions" path drops the build with no error message. The package's newest release becomes invisible to the resolver.

## Repro

```js
let T = require('./triplet.js');
let v101 = {
    name: 'serviceman-v1.0.1.tar.gz',
    version: '1.0.1',
    ext: 'tar.gz',
    download: 'https://api.github.com/repos/bnnanet/serviceman/tarball/v1.0.1',
};
T.maybeInstallable({ name: 'serviceman' }, v101);
// before: false   ← bug
// after:  true
```

## Fix

Check `build.name` (the canonical filename) instead of `build.download`. The filename for `serviceman-v1.0.1.tar.gz` ends in `.tar.gz`, not `.1`. Real `.1` man-page files have `.1` in their `name` too, so detection of those is unaffected. Same change applied to the `_RE_TERMS_NON_BUILD` loop for consistency.

## Test plan

- [x] Unit verification (in commit message body):
  - `serviceman-v1.0.1.tar.gz` → `true` (was `false`)
  - `serviceman-v1.0.0.tar.gz` → `true` (unchanged)
  - `mytool.1` (manpage) → `false` (unchanged)
- [ ] Run webicached + `webi serviceman` end-to-end and confirm v1.0.1 (or whatever the newest patch.1 version is) resolves to the tarball, not v1.0.0.
- [ ] Confirm no regression in other packages — particularly any that publish actual `.1`/`.deb`/`.rpm`/etc. files.

## Impact

Affects any package whose version ends in `.1` and whose download URL is a GitHub source-archive endpoint (`/tarball/vX.Y.1` or `/zipball/vX.Y.1`). Observed in the wild for `serviceman` v1.0.1 (patch releases generally), `aliasman`, and the source-only vim plugins.

Surfaced while validating PR #1074 in webinstall/webi-installers — the resolver was returning v1.0.0 instead of v1.0.1 for serviceman, which traced back to this classifier rejection.