### PR TITLE
fix(lexver): parsePrefix output should always be a string-prefix of parseVersion

### DIFF
--- a/lexver.js
+++ b/lexver.js
@@ -126,7 +126,9 @@ Lexver.parseVersion = function (fullVersion, _opts) {
   }
 
   // 1, 0 => 1, 0, 0, 0
-  if (!_opts?._asPrefix) {
+  // Pad to 4 even for prefix parses when input has a release suffix —
+  // keeps parsePrefix(v) a true string-prefix of parseVersion(v).
+  if (!_opts?._asPrefix || rels.length) {
     for (; digits.length < 4; ) {
       digits.push('0');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "build-classifier",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "build-classifier",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "SEE LICENSE IN LICENSE"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-classifier",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Determine Host Target Triplet (Arch, Libc, OS, Vendor) from a filenames / download URL and uname / User-Agent strings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`parsePrefix(v)` must always be a string-prefix of `parseVersion(v)` — `matchSorted` uses `startsWith`. The invariant breaks when the input has a release suffix because `parsePrefix` skips zero-padding while `parseVersion` pads:

```js
parseVersion('1.0.0-beta')  // '0001.0000.0000.0000-beta'
parsePrefix('1.0.0-beta')   //         '0001.0000.0000-beta'   ← not a prefix
```

Fix: when there's a release suffix, treat the input as a complete version (not a partial prefix) — pad to 4 digit components before appending the suffix. Partial inputs like `1.0` still skip padding.

Verified for `1.0.0-beta`, `2025.11.15-15.42.45`, `1.991`, `1.0`, `v1.991.1+hotfix1` — all satisfy the invariant. Existing `lexver-test.js` still passes.